### PR TITLE
Require applicant type selection

### DIFF
--- a/Controllers/PermitController.cs
+++ b/Controllers/PermitController.cs
@@ -925,7 +925,7 @@ namespace PerizinanPeternakan.Controllers
                 // ===============================================
                 if (string.IsNullOrEmpty(model.ApplicantType))
                 {
-                    model.ApplicantType = "Company";
+                    ModelState.AddModelError("ApplicantType", "Tipe pemohon harus dipilih");
                 }
 
                 Console.WriteLine($"🔍 ApplicantType: '{model.ApplicantType}'");

--- a/ViewModels/PermitViewModels.cs
+++ b/ViewModels/PermitViewModels.cs
@@ -19,8 +19,9 @@ namespace PerizinanPeternakan.ViewModels
         [Display(Name = "Nama Dokumen Opsional")]
         public string? DokumenOpsionalNama { get; set; }
 
+        [Required(ErrorMessage = "Tipe pemohon harus dipilih")]
         [Display(Name = "Tipe Pemohon")]
-        public string ApplicantType { get; set; } = "Company"; 
+        public string? ApplicantType { get; set; }
 
         [Display(Name = "Provinsi Asal")]
         public int? OriginProvinceId { get; set; }

--- a/Views/Permit/Create.cshtml
+++ b/Views/Permit/Create.cshtml
@@ -104,7 +104,7 @@
                             <div class="applicant-type-selection">
                                 <div class="radio-group">
                                     <div class="radio-item">
-                                        <input type="radio" id="individual" name="ApplicantType" value="Individual" class="form-radio" />
+                                        <input asp-for="ApplicantType" type="radio" id="individual" value="Individual" class="form-radio" />
                                         <label for="individual" class="radio-label">
                                             <div class="radio-content">
                                                 <i class="fas fa-user"></i>
@@ -114,7 +114,7 @@
                                         </label>
                                     </div>
                                     <div class="radio-item">
-                                        <input type="radio" id="company" name="ApplicantType" value="Company" class="form-radio" checked />
+                                        <input asp-for="ApplicantType" type="radio" id="company" value="Company" class="form-radio" />
                                         <label for="company" class="radio-label">
                                             <div class="radio-content">
                                                 <i class="fas fa-building"></i>
@@ -124,6 +124,7 @@
                                         </label>
                                     </div>
                                 </div>
+                                <span asp-validation-for="ApplicantType" class="text-danger"></span>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- enforce selection of applicant type on permit application
- bind applicant type radio buttons to model and show validation errors
- ensure create action surfaces errors when applicant type is missing

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ad02641c4832f93742486e101270d